### PR TITLE
Fix typo

### DIFF
--- a/update.py
+++ b/update.py
@@ -92,7 +92,7 @@ async def update_one_bgm_data(
             lambda: client.post(
                 f'https://api.bgm.tv/collection/{bgm_id}/update',
                 data={'status': status},
-                headers={'Authorization': data.auth_data}
+                headers={'Authorization': data.bgm_auth_data}
             )
         )
         response.raise_for_status()


### PR DESCRIPTION
不存在字段 'auth_data'，只有'bgm_auth_data'
未修改前报错信息：

> Traceback (most recent call last):
  File "bili2bgm.py", line 44, in <module>
    loop.run_until_complete(main())
  File "D:\anaconda3\lib\asyncio\base_events.py", line 579, in run_until_complete
    return future.result()
  File "bili2bgm.py", line 38, in main
    await get_and_update(bili2bgm_map, bili_auth_data, BILI_UID, bgm_auth_data)
  File "update.py", line 241, in get_and_update
    await data.update_bgm_data_task
  File "update.py", line 137, in update_bgm_data
    await gather(*data.update_one_bgm_data_tasks)
  File "update.py", line 92, in update_one_bgm_data
    lambda: client.post(
  File "utilities.py", line 67, in try_for_times_async_chain
    result = await func()
  File "update.py", line 95, in <lambda>
    headers={'Authorization': data.auth_data}
AttributeError: 'types.SimpleNamespace' object has no attribute 'auth_data'

